### PR TITLE
Add optional support for DynamoDB's DocumentClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 *.tmproj
 *.sublime-project
 dump.rdb
+.idea

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ secretAccessKey : your AWS secret access key
 region          : the region where the domain is hosted
 useEnvironment  : use process.env values for AWS access, secret, & region
 tableName       : DynamoDB table name
+dynamoDoc       : if this is set to true, the *meta* parameter will be stored as a subobject using DynamoDB's DocumentClient rather than as a JSON string.
 ```
 
 ## Prerequisite

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   ],
   "dependencies": {
     "aws-sdk": "^2.1.32",
-    "node-uuid": "1.4.*",
-    "lodash": "^3.9.3"
+    "lodash": "^4.12.0",
+    "node-uuid": "1.4.*"
   },
   "devDependencies": {
     "gulp": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "winston-dynamodb",
   "description": "A Winston transport for Amazon DynamoDB",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "JeongWoo Chang",
     "email": "inspired.jw@gmail.com"


### PR DESCRIPTION
My project requires that the _meta_ parameter be stored as a sub-object, rather than as a JSON-encoded string. Therefore, I've added a new dynamoDoc parameter that determines if amazon's [DocumentClient](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html) should be used  instead of the existing transport method.